### PR TITLE
Fix: Dockerfile yarn install 캐싱되게 수정(#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM node
 
 WORKDIR /app
 
-COPY . .
+COPY package.json yarn.lock ./
 
 RUN yarn install
+
+COPY . .
 
 RUN yarn build
 


### PR DESCRIPTION
## 기능에 대한 설명
코드를 수정해서 `COPY . .` 하는 부분이 `RUN yarn install`보다 위에 있어서 그 하위작업에대해 캐싱을 진행하지 못하는 문제가 있었어요.

그래서 코드를 조금만 수정해도 yarn install이 매번 진행되는 문제가 있었는데, 그것을 수정하였스빈다!


## ISSUE
close #28 