### PR TITLE
Fix: 이름으로 유저정보를 찾는 API 추가

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,9 +2,7 @@ import {
   Body,
   Controller,
   Get,
-  Head,
   Param,
-  ParseUUIDPipe,
   Patch,
   Post,
   UploadedFile,
@@ -57,22 +55,11 @@ export class UsersController {
   }
 
   @ApiCookieAuth()
-  @ApiOperation({ summary: 'id로 유저 정보를 가져옵니다.' })
+  @ApiOperation({ summary: '닉네임으로 유저 정보를 가져옵니다.' })
   @ApiResponse({ status: 200, description: '성공' })
   @ApiResponse({ status: 403, description: '세션 인증 실패' })
   @ApiResponse({ status: 404, description: '유저 없음' })
-  @Get(':uuid')
-  @UseGuards(UserCreatedGuard)
-  getUserById(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<User> {
-    return this.usersService.getUserById(uuid);
-  }
-
-  @ApiCookieAuth()
-  @ApiOperation({ summary: '중복 닉네임을 확인합니다.' })
-  @ApiResponse({ status: 200, description: '성공' })
-  @ApiResponse({ status: 403, description: '세션 인증 실패' })
-  @ApiResponse({ status: 404, description: '유저 없음' })
-  @Head('name/:name')
+  @Get(':name')
   getUserByName(@Param('name') name: string): Promise<User> {
     return this.usersService.getUserByName(name);
   }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -10,14 +10,6 @@ import { User } from './user.entity';
 
 @EntityRepository(User)
 export class UsersRepository extends Repository<User> {
-  async getUserById(id: string): Promise<User> {
-    const found: User = await this.findOne({ id });
-    if (!found) {
-      throw new NotFoundException(`User with ${id} not found`);
-    }
-    return found;
-  }
-
   async getUserByName(name: string): Promise<User> {
     const found: User = await this.findOne({ name });
     if (!found) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -16,10 +16,6 @@ export class UsersService {
     return await this.usersRepository.find();
   }
 
-  getUserById(id: string): Promise<User> {
-    return this.usersRepository.getUserById(id);
-  }
-
   getUserByName(name: string): Promise<User> {
     return this.usersRepository.getUserByName(name);
   }


### PR DESCRIPTION
## 기능에 대한 설명
```
추가된 API:    GET /users/:name

삭제된 API:    GET /users/:uuid
            HEAD /users/name/:name
```
### 추가된 API
1. `GET` `/users/:name`
    - `:name`으로 유저를 검색하는 API를 추가했습니다.

### 삭제된 API
1. `GET` `/users/:uuid` 
    - 사용하지 않게 될 `:uuid`로 검색하는 API는 삭제했어요.
2. `HEAD` `/users/name/:name`
    - 기존에 닉네임 검사용으로 사용했던 API인데, 닉네임으로 유저를 검색하는 API가 추가됨에 따라 기능이 중복되어 삭제했어요.
    - ***닉네임을 검사하는 API가 수정***되었으므로 이부분을 ***프론트엔드쪽에서도 수정할 것***이 요구되는 사항입니다!

## ISSUE
close #55