### PR TITLE
Fix: enable2FA를 수정할 수 없었던 문제 수정

### DIFF
--- a/src/auth/guards/google-authenticator.guard.ts
+++ b/src/auth/guards/google-authenticator.guard.ts
@@ -1,11 +1,21 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
 
 @Injectable()
 export class GoogleAuthenticatorGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
     console.log('GoogleAuthenticatorGuard');
     if (req.user?.enable2FA) {
+      if (!req.user?.authenticatorSecret) {
+        const res: Response = context.switchToHttp().getResponse();
+        res.redirect(
+          this.configService.get<string>('ORIGIN') + '/register/2fa',
+        );
+      }
       return req.user?.isSecondFactorAuthenticated;
     }
     return true;

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersRepository } from './users.repository';
@@ -7,6 +8,6 @@ import { UsersService } from './users.service';
 @Module({
   imports: [TypeOrmModule.forFeature([UsersRepository])],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, ConfigService],
 })
 export class UsersModule {}

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -63,9 +63,9 @@ export class UsersRepository extends Repository<User> {
     if (file) {
       user.avatar = file.path;
     }
-    if (enable2FA === 'true') {
+    if (enable2FA) {
       user.enable2FA = enable2FA === 'true';
-      user.isSecondFactorAuthenticated = true; // REVIEW 업데이트하고 바로 인증으로 넘어가지 않고, 재로그인시 검사
+      user.isSecondFactorAuthenticated = enable2FA === 'true';
     }
     try {
       await this.save(user);

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -66,6 +66,7 @@ export class UsersRepository extends Repository<User> {
     if (enable2FA) {
       user.enable2FA = enable2FA === 'true';
       user.isSecondFactorAuthenticated = enable2FA === 'true';
+      user.authenticatorSecret = null;
     }
     try {
       await this.save(user);


### PR DESCRIPTION
## 기능에 대한 설명
#58 이슈에 대한 FIX PR입니다.
회원정보 수정에서 enable2FA를 수정했을 때, 응답은 200번대로 제대로 응답이 오지만 실제 값은 변경되지 않았던 문제가 있었는데, 그 부분을 수정하였습니다. 

[+]

#61 이슈에 대한 작업도 추가했습니다.
리디렉션하는 로직을 추가했는데, 이제 구글인증권한이 필요한 모든 요청에 대해서 `authenticatorSecret` 필드가 `null`이면 리디렉션을 진행하도록 수정되었습니다.

## ISSUE
close #58
