### PR TITLE
Feat: mute 기능 추가(#43)

### DIFF
--- a/.env.stage.dev
+++ b/.env.stage.dev
@@ -1,3 +1,5 @@
+TZ=UTC
+
 # 42 app credentials
 
 FT_APP_ID=7217a681d93cc93f0ccf225dafe8d80d0cea597004afa1d790672a308eef54dc

--- a/.env.stage.prod
+++ b/.env.stage.prod
@@ -1,3 +1,5 @@
+TZ=UTC
+
 # 42 app credentials
 
 FT_APP_ID=7217a681d93cc93f0ccf225dafe8d80d0cea597004afa1d790672a308eef54dc

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -145,6 +145,20 @@ export class ChannelsController {
     );
   }
 
+  @ApiOperation({
+    summary: '특정 채널에서 특정 유저를 음소거합니다.',
+  })
+  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({ status: 404, description: '채널, 유저 없음' })
+  @Patch(':name/members/:memberName/mute')
+  updateChannelMemberMute(
+    @GetUser() user: User,
+    @Param('name') name: string,
+    @Param('memberName') memberName: string,
+  ): Promise<Membership> {
+    return this.channelsService.updateChannelMemberMute(user, name, memberName);
+  }
+
   @ApiOperation({ summary: '특정 채널의 채팅을 추가합니다.' })
   @ApiResponse({ status: 200, description: '성공' })
   @ApiResponse({ status: 404, description: '채널 없음' })

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -306,6 +306,63 @@ export class ChannelsService {
     return membershipOfMember;
   }
 
+  async updateChannelMemberMute(
+    user: User,
+    name: string,
+    memberName: string,
+  ): Promise<Membership> {
+    if (user.name === memberName) {
+      throw new ForbiddenException(['Cannot change yourself.']);
+    }
+    const channel: Channel = await this.getChannelByName(name);
+    const membershipOfRequester: Membership =
+      await this.membershipsRepository.findOne({ channel, user });
+    if (!membershipOfRequester) {
+      throw new NotFoundException([
+        `${user.name} is not a member of channel(${name}).`,
+      ]);
+    }
+
+    if (
+      membershipOfRequester.role !== MembershipRole.OWNER &&
+      membershipOfRequester.role !== MembershipRole.ADMIN
+    ) {
+      throw new ForbiddenException(['You do not have permission.']);
+    }
+
+    const member: User = await this.usersService.getUserByName(memberName);
+    const membershipOfMember: Membership =
+      await this.membershipsRepository.findOne({ channel, user: member });
+    if (!membershipOfMember) {
+      throw new NotFoundException([
+        `${memberName} is not a member of channel(${name}).`,
+      ]);
+    }
+
+    switch (membershipOfMember.role) {
+      case MembershipRole.OWNER:
+        // NOTE 상대가 OWNER일 경우, 강퇴 불가
+        throw new ForbiddenException(['You do not have permission.']);
+
+      case MembershipRole.ADMIN:
+        // NOTE 상대가 ADMIN일 경우, OWNER만 강퇴 가능
+        if (membershipOfRequester.role !== MembershipRole.OWNER) {
+          throw new ForbiddenException(['You do not have permission.']);
+        }
+        break;
+      case MembershipRole.BANNED:
+        throw new ForbiddenException(['You cannot mute an banned user.']);
+    }
+
+    membershipOfMember.mutedAt = new Date();
+
+    await this.membershipsRepository.update(
+      { channel, user: member },
+      { channel, user: member, mutedAt: membershipOfMember.mutedAt },
+    );
+    return membershipOfMember;
+  }
+
   async createChannelChat(
     name: string,
     user: User,
@@ -317,6 +374,20 @@ export class ChannelsService {
       user,
       channel,
     });
+
+    if (isMember.mutedAt) {
+      const now: Date = new Date();
+
+      const unmutedAt: Date = isMember.mutedAt;
+      unmutedAt.setMinutes(unmutedAt.getMinutes() + 1); // NOTE add 1 minute
+
+      const left = unmutedAt.valueOf() - now.valueOf();
+      if (left > 0) {
+        throw new ForbiddenException(
+          `Mute ends ${Math.floor(left / 1000)} seconds later.`,
+        );
+      }
+    }
 
     if (!isMember || isMember.role === MembershipRole.BANNED) {
       throw new ForbiddenException(['You are not a member of this channel.']);

--- a/src/channels/entities/membership.entity.ts
+++ b/src/channels/entities/membership.entity.ts
@@ -26,4 +26,10 @@ export class Membership {
     default: MembershipRole.MEMBER,
   })
   role: MembershipRole;
+
+  @Column({
+    nullable: true,
+    default: null,
+  })
+  mutedAt: Date;
 }


### PR DESCRIPTION
## 기능에 대한 설명
`PATCH` `/channels/:name/members/:memberName/mute` API 추가
mute가 설정된 유저는 설정 시각으로 부터 `1분` 뒤에 채팅을 전송할 수 있음.

## 테스트 (Optional)
timezone UTC로 적용되는지 확인.
mute 설정 뒤 1분뒤에 채팅이 전송되는지의 여부 테스트함.

## ISSUE
#43 