### PR TITLE
Fix: 특정채널에서 퇴장하는 API를 memberName parameter를 받도록 수정

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -117,12 +117,13 @@ export class ChannelsController {
   @ApiOperation({ summary: '특정 채널에서 퇴장합니다.' })
   @ApiResponse({ status: 200, description: '성공' })
   @ApiResponse({ status: 404, description: '채널, 유저 없음' })
-  @Delete(':name/members/me')
-  deleteChannelMemberByMe(
+  @Delete(':name/members/:memberName')
+  deleteChannelMember(
     @GetUser() user: User,
     @Param('name') name: string,
+    @Param('memberName') memberName: string,
   ): Promise<void> {
-    return this.channelsService.deleteChannelMemberByMe(user, name);
+    return this.channelsService.deleteChannelMember(user, name, memberName);
   }
 
   @ApiOperation({


### PR DESCRIPTION
> ⚠️ 이슈 없이 Pull Request 금지  
> 아래 항목은 필수이지만, 필요없다고 생각하는 부분은 삭제하고 필요한 부분은 자유롭게 추가 가능

## 기능에 대한 설명
BANNED을 풀어주는 API가 필요해서 그 부분을 구현했습니다.
https://42born2code.slack.com/archives/C028H0MJULC/p1631605949005500

`DELETE` `/channels/:name/members/me` to `DELETE` `/channels/:name/members/:memberName`

memberName이 본인이 아닐 경우, BANNED일때만 삭제 가능