### PR TITLE
Feat: 유저의 승, 패 정보 추가

### DIFF
--- a/src/events/games/room-manager.service.ts
+++ b/src/events/games/room-manager.service.ts
@@ -110,12 +110,14 @@ export class RoomManagerService {
           await this.usersRepository.update(winner.id, {
             status: UserStatus.ONLINE,
             score: winner.score + 10,
+            win: winner.win + 1,
           });
         } else {
           loser = user;
           await this.usersRepository.update(loser.id, {
             status: UserStatus.ONLINE,
             score: loser.score - 10,
+            lose: loser.lose + 1,
           });
         }
         const message: string =

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -42,7 +42,14 @@ export class User {
   isSecondFactorAuthenticated: boolean;
 
   @Column({ default: 0 })
+  win: number;
+
+  @Column({ default: 0 })
+  lose: number;
+
+  @Column({ default: 0 })
   score: number;
+
   @OneToMany(() => Membership, (membership) => membership.user, {
     cascade: true,
   })


### PR DESCRIPTION
> ⚠️ 이슈 없이 Pull Request 금지  
> 아래 항목은 필수이지만, 필요없다고 생각하는 부분은 삭제하고 필요한 부분은 자유롭게 추가 가능

## 기능에 대한 설명
유저의 승 패 정보를 추가했습니다.

## 테스트 (Optional)
게임종료 뒤 승과 패가 올라가는걸 확인했어요.

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE
close #106