### PR TITLE
Fix: 초대, 수락, 거절 이벤트에서 나의 접속 상태도 고려하도록 수정

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -153,14 +153,18 @@ export class EventsService {
   ): Promise<void> {
     const opponent: User = await this.usersRepository.findOne(opponentId);
 
-    if (opponent?.status !== UserStatus.ONLINE) {
+    const user: User = await this.usersRepository.findOne(
+      client.handshake.query.userId as string,
+    );
+
+    if (
+      user?.status !== UserStatus.ONLINE &&
+      opponent?.status !== UserStatus.ONLINE
+    ) {
       server.to(client.id).emit('declined', {
         message: `${opponent?.name}(${opponent?.status}) cannot receive your invitation.`,
       });
     } else {
-      const user: User = await this.usersRepository.findOne(
-        client.handshake.query.userId as string,
-      );
       server.to(opponentId).emit('invitedToMatch', {
         mode,
         opponent: user,
@@ -176,7 +180,14 @@ export class EventsService {
   ): Promise<void> {
     const opponent: User = await this.usersRepository.findOne(opponentId);
 
-    if (opponent?.status !== UserStatus.ONLINE) {
+    const user: User = await this.usersRepository.findOne(
+      client.handshake.query.userId as string,
+    );
+
+    if (
+      user?.status !== UserStatus.ONLINE &&
+      opponent?.status !== UserStatus.ONLINE
+    ) {
       server.to(client.id).emit('canceled', {
         message: `You cannot accept ${opponent?.name}(${opponent?.status})'s invitation.`,
       });
@@ -206,7 +217,14 @@ export class EventsService {
   ): Promise<void> {
     const opponent: User = await this.usersRepository.findOne(opponentId);
 
-    if (opponent?.status !== UserStatus.ONLINE) {
+    const user: User = await this.usersRepository.findOne(
+      client.handshake.query.userId as string,
+    );
+
+    if (
+      user?.status !== UserStatus.ONLINE &&
+      opponent?.status !== UserStatus.ONLINE
+    ) {
       server.to(client.id).emit('canceled', {
         message: `You cannot decline ${opponent?.name}(${opponent?.status})'s invitation.`,
       });

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -186,6 +186,11 @@ export class EventsService {
     mode: MatchGameMode,
     opponentId: string,
   ): Promise<void> {
+    const opponentSocketId: string = await this.getOpponentSocketId(
+      server,
+      opponentId,
+    );
+
     const opponent: User = await this.usersRepository.findOne(opponentId);
 
     const user: User = await this.usersRepository.findOne(
@@ -193,6 +198,7 @@ export class EventsService {
     );
 
     if (
+      !opponentSocketId &&
       user?.status !== UserStatus.ONLINE &&
       opponent?.status !== UserStatus.ONLINE
     ) {
@@ -200,11 +206,6 @@ export class EventsService {
         message: `You cannot accept ${opponent?.name}(${opponent?.status})'s invitation.`,
       });
     } else {
-      const opponentSocketId: string = await this.getOpponentSocketId(
-        server,
-        opponentId,
-      );
-
       const opponentSocket: Socket =
         server.sockets.sockets.get(opponentSocketId);
 


### PR DESCRIPTION
## 기능에 대한 설명
매치 초대, 수락, 거절 이벤트에서 나의 접속상태도 고려해서 이벤트를 보내도록 수정했습니다.

## ISSUE
close: #122 