### PR TITLE
Feat: 첫 게임, 첫 승리, 첫 패배 업적 추가

### DIFF
--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -3,7 +3,10 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChannelsRepository } from 'src/channels/repositories/channels.repository';
 import { MatchesRepository } from 'src/matches/matches.repository';
+import { AchievementsRepository } from 'src/users/repositories/achievement.repository';
+import { UserAchievementsRepository } from 'src/users/repositories/user-achievement.repository';
 import { UsersRepository } from 'src/users/repositories/users.repository';
+import { UsersService } from 'src/users/users.service';
 import { EventsGateway } from './events.gateway';
 import { EventsService } from './events.service';
 import { GameManagerService } from './games/game-manager.service';
@@ -16,6 +19,8 @@ import { RoomManagerService } from './games/room-manager.service';
       ChannelsRepository,
       UsersRepository,
       MatchesRepository,
+      AchievementsRepository,
+      UserAchievementsRepository,
     ]),
     ScheduleModule.forRoot(),
   ],
@@ -25,6 +30,7 @@ import { RoomManagerService } from './games/room-manager.service';
     LobbyManagerService,
     RoomManagerService,
     GameManagerService,
+    UsersService,
   ],
   exports: [EventsGateway],
 })


### PR DESCRIPTION
## 기능에 대한 설명
첫 게임, 첫 승리, 첫 패배 업적을 추가했습니다.

## 테스트 (Optional)
업적이 취득되는지 여부를 확인했어요.
![Screen Shot 2021-10-06 at 12 33 28 PM](https://user-images.githubusercontent.com/16534576/136136557-f019069d-413e-4052-8bfd-329d0f517839.png)


## ISSUE
See also: #32